### PR TITLE
Feat/arc importer

### DIFF
--- a/lua/glorifiedbanking/modules/integrations/sv_glorifiedbanking_arcbank.lua
+++ b/lua/glorifiedbanking/modules/integrations/sv_glorifiedbanking_arcbank.lua
@@ -194,7 +194,13 @@ function GlorifiedBanking.ARCBank.ImportFromSQL(notify)
 		elseif steamid ~= "BOT" then
 			local sid = util.SteamIDTo64(steamid)
 			sid = GlorifiedBanking.SQL.EscapeString(sid)
-			GlorifiedBanking.SQL.Query("REPLACE INTO gb_players (`SteamID`, `Balance`) VALUES ('" .. sid .. "', " .. refund .. ")")
+			GlorifiedBanking.SQL.Query("REPLACE INTO gb_players (`SteamID`, `Balance`) VALUES ('" .. sid .. "', " .. refund .. ")", function()
+				local ply = player.GetBySteamID(steamid)
+				if IsValid(ply) and ply:IsPlayer() then
+		            ply.GlorifiedBanking.Balance = refund
+            		ply:SetNW2Int("GlorifiedBanking.Balance", refund)
+        		end
+			end)
 		end
 	end
 end


### PR DESCRIPTION
ArcBank data importer.
Currently only works for SQL based installs.

Group accounts are refunded based on deposits (amountPersonDeposited / totalDeposited) * amountInAccount.
Debts in group accounts are ignored.
People with amountDeposited < 0 aren't refunded from that account.

Personal accounts are refunded fully.
Debts in personal accounts aren't ignored.

All group & personal accounts are merged and summed.
Any person with a positive total refund will have an account generated with that amount in it by default.
Any person with 0 or negative refund won't have an account made.

This has been tested with a single data set, and seems to be working, but I can't fully confirm.